### PR TITLE
Replace non-ASCII characters in R/ source files

### DIFF
--- a/R/anztox_data.R
+++ b/R/anztox_data.R
@@ -38,7 +38,7 @@
 #'    curated CAS parent lookup. Endpoint labels from 2016 are mapped to 2000
 #'    effect codes.
 #'
-#' 2. **Test type priority**: Within each species × chemical × endpoint group,
+#' 2. **Test type priority**: Within each species x chemical x endpoint group,
 #'    chronic data are preferred over subchronic, and subchronic over acute.
 #'
 #' 3. **Acute-to-chronic conversion**: Where only acute data are available for
@@ -46,12 +46,12 @@
 #'    (Warne et al. 2025, Section 3.4.2.2) to obtain chronic negligible-effect
 #'    equivalents before SSD fitting.
 #'
-#' 4. **Aggregation**: Concentration values for the same species × endpoint are
+#' 4. **Aggregation**: Concentration values for the same species x endpoint are
 #'    geometric-mean averaged. The most sensitive endpoint per species is
 #'    retained.
 #'
-#' 5. **Eligibility threshold**: Only chemical × media combinations with ≥ 5
-#'    species from ≥ 4 distinct major taxonomic groups are retained. These are
+#' 5. **Eligibility threshold**: Only chemical x media combinations with >= 5
+#'    species from >= 4 distinct major taxonomic groups are retained. These are
 #'    then nested into a list-column ready for SSD fitting or related functions.
 #'
 #' The columns are as follows:
@@ -63,10 +63,10 @@
 #'   compound name where applicable (chr).}
 #'\item{mediatype}{Water type: "Freshwater" or "Marine" (chr).}
 #'\item{data}{A list-column containing a tibble of species-level rows for that
-#'   chemical × media combination. Each row represents a single species and
+#'   chemical x media combination. Each row represents a single species and
 #'   contains columns: `scientificname`, `commonname_species`,
 #'   `majorgroup`, `minorgroup`, `endpoint`,
-#'   `endpoint_concentration` (geometric mean concentration in µg/L or mg/L,
+#'   `endpoint_concentration` (geometric mean concentration in ug/L or mg/L,
 #'   depending on the chemical), `testtype` (Chronic or Acute),
 #'   `source_datasets` (comma-separated source: "2000", "2016", or both),
 #'   and `n_acute_converted` (count of acute records that contributed to
@@ -75,7 +75,7 @@
 #'
 #' @name anztox_data
 #' @docType data
-#' @format A tibble with one row per chemical × mediatype combination and columns:
+#' @format A tibble with one row per chemical x mediatype combination and columns:
 #' \describe{
 #'   \item{casnumber_grouped}{Grouped CAS number (character).}
 #'   \item{chemicalname_grouped}{Grouped chemical name (character).}

--- a/R/get_ssddata.R
+++ b/R/get_ssddata.R
@@ -201,7 +201,7 @@ list_datasets <- function() {
 #'   - `"alldata"`: aggregates all `*_data` sources and splits by `Chemical`
 #'
 #'   **Note:** aggregated values (`"wqbench"`, `"envirotox_acute"`,
-#'   `"envirotox_chronic"`, `"anztox"`, `"alldata"`) must be passed alone — they
+#'   `"envirotox_chronic"`, `"anztox"`, `"alldata"`) must be passed alone - they
 #'   cannot be combined with each other or with prefix strings (e.g.
 #'   `c("wqbench", "ccme")` is not supported and will error).
 #' @param split A character vector of column names to further split datasets by
@@ -459,7 +459,7 @@ ssd_data_sets <- function(
       }
     }
 
-    # anztox: unnest inner tibbles per Chemical x Medium — already have
+    # anztox: unnest inner tibbles per Chemical x Medium - already have
     # Species, Conc, Chemical, Medium columns from DATASET.R
     anztox_raw <- .pkgdata("anztox_data")
     for (i in seq_len(nrow(anztox_raw))) {
@@ -493,7 +493,7 @@ ssd_data_sets <- function(
     return(all_out)
   }
 
-  # wqbench / envirotox_acute / envirotox_chronic — flat tibbles, split by Chemical
+  # wqbench / envirotox_acute / envirotox_chronic - flat tibbles, split by Chemical
   raw_name <- switch(
     set,
     wqbench = "wqbench_data",

--- a/man/anztox_data.Rd
+++ b/man/anztox_data.Rd
@@ -5,7 +5,7 @@
 \alias{anztox_data}
 \title{ANZTOX Species Sensitivity Data}
 \format{
-A tibble with one row per chemical × mediatype combination and columns:
+A tibble with one row per chemical x mediatype combination and columns:
 \describe{
 \item{casnumber_grouped}{Grouped CAS number (character).}
 \item{chemicalname_grouped}{Grouped chemical name (character).}
@@ -50,17 +50,17 @@ endpoint vocabulary and were de-normalised, cleaned, and combined into a single
 table. Chemical variants and salts are mapped to parent compounds via a
 curated CAS parent lookup. Endpoint labels from 2016 are mapped to 2000
 effect codes.
-\item \strong{Test type priority}: Within each species × chemical × endpoint group,
+\item \strong{Test type priority}: Within each species x chemical x endpoint group,
 chronic data are preferred over subchronic, and subchronic over acute.
 \item \strong{Acute-to-chronic conversion}: Where only acute data are available for
 a species, acute LC/EC/IC50 values are divided by a default ACR of 10
 (Warne et al. 2025, Section 3.4.2.2) to obtain chronic negligible-effect
 equivalents before SSD fitting.
-\item \strong{Aggregation}: Concentration values for the same species × endpoint are
+\item \strong{Aggregation}: Concentration values for the same species x endpoint are
 geometric-mean averaged. The most sensitive endpoint per species is
 retained.
-\item \strong{Eligibility threshold}: Only chemical × media combinations with ≥ 5
-species from ≥ 4 distinct major taxonomic groups are retained. These are
+\item \strong{Eligibility threshold}: Only chemical x media combinations with >= 5
+species from >= 4 distinct major taxonomic groups are retained. These are
 then nested into a list-column ready for SSD fitting or related functions.
 }
 
@@ -73,10 +73,10 @@ compound where applicable (chr).}
 compound name where applicable (chr).}
 \item{mediatype}{Water type: "Freshwater" or "Marine" (chr).}
 \item{data}{A list-column containing a tibble of species-level rows for that
-chemical × media combination. Each row represents a single species and
+chemical x media combination. Each row represents a single species and
 contains columns: \code{scientificname}, \code{commonname_species},
 \code{majorgroup}, \code{minorgroup}, \code{endpoint},
-\code{endpoint_concentration} (geometric mean concentration in µg/L or mg/L,
+\code{endpoint_concentration} (geometric mean concentration in ug/L or mg/L,
 depending on the chemical), \code{testtype} (Chronic or Acute),
 \code{source_datasets} (comma-separated source: "2000", "2016", or both),
 and \code{n_acute_converted} (count of acute records that contributed to

--- a/man/ssd_data_sets.Rd
+++ b/man/ssd_data_sets.Rd
@@ -26,7 +26,7 @@ returned. Options:
 }
 
 \strong{Note:} aggregated values (\code{"wqbench"}, \code{"envirotox_acute"},
-\code{"envirotox_chronic"}, \code{"anztox"}, \code{"alldata"}) must be passed alone — they
+\code{"envirotox_chronic"}, \code{"anztox"}, \code{"alldata"}) must be passed alone - they
 cannot be combined with each other or with prefix strings (e.g.
 \code{c("wqbench", "ccme")} is not supported and will error).}
 


### PR DESCRIPTION
Fixes #38.

## Summary

Replaces non-ASCII characters in the roxygen documentation of `R/anztox_data.R` and `R/get_ssddata.R` (and the corresponding generated `man/anztox_data.Rd` / `man/ssd_data_sets.Rd`) with ASCII equivalents, for portability — `R CMD check` flags non-ASCII characters in R source files.

| From | To |
|---|---|
| `×` (multiplication sign) | `x` |
| `≥` | `>=` |
| `µ` (in `µg/L`) | `u` |
| em-dash `—` | `-` |

Documentation only; no change to package behaviour. The `man/*.Rd` edits mirror exactly what `devtools::document()` would regenerate from the updated roxygen.

## Test plan

- [ ] `R CMD check` (not run here)

Opened as a draft pending maintainer review.