### PR TITLE
Validate dataset names and disambiguate colliding anztox set names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Bug fixes
 
+- `ssd_data_sets(set = "anztox")` no longer returns two elements with the same
+  name (GitHub #50). Two CAS can share one grouped chemical name — Aroclor 1254
+  and Aroclor 1242 are both "Polychlorinated biphenyls" — which made one element
+  unreachable, since `[[name]]` returns the first match. Colliding names are now
+  suffixed with their CAS; all other element names are unchanged.
+- `get_ssddata()` now errors for an unknown `dataset_name` instead of warning and
+  returning `NULL` (GitHub #54), and `ssd_data_sets(set = NA)` reports a missing
+  value rather than failing with "missing value where TRUE/FALSE needed".
 - Added the missing species names to `csiro_chlorine_marine`, which shipped all
   30 of its rows with a blank `Species`. The names were reconstructed from
   Batley & Simpson (2020). The dataset now also carries `Duration`,

--- a/R/get_ssddata.R
+++ b/R/get_ssddata.R
@@ -44,6 +44,20 @@ get_ssddata <- function(
     }
   }
   chk_string(dataset_name)
+  # Validate that the name refers to a real dataset. utils::data() only warns
+  # on a miss and returns an empty result, so without this a mistyped name
+  # falls through to the "no grouping applied" branch and returns NULL - much
+  # harder to trace from inside a fitting pipeline than an error here.
+  valid_datasets <- utils::data(package = "ssddata")$results[, "Item"]
+  if (!dataset_name %in% valid_datasets) {
+    stop(
+      "`dataset_name` '",
+      dataset_name,
+      "' is not a dataset in ssddata. ",
+      "See ssd_data_sets() for available datasets.",
+      call. = FALSE
+    )
+  }
   chk_null_or(filter_val, vld = vld_string)
   chk_flag(use_gmmean)
   chk_string(conc)
@@ -108,6 +122,11 @@ get_ssddata <- function(
 getdata <- function(...) {
   e <- new.env()
   name <- utils::data(..., envir = e)[1]
+  # utils::data() warns rather than errors on an unknown name, leaving `name`
+  # NA and e[[name]] NULL. Error instead so callers never receive a silent NULL.
+  if (is.na(name) || !exists(name, envir = e, inherits = FALSE)) {
+    stop("data set not found.", call. = FALSE)
+  }
   e[[name]]
 }
 
@@ -232,6 +251,10 @@ ssd_data_sets <- function(
   cas_lookup = TRUE
 ) {
   chk::chk_character(set)
+  # chk_character() admits NA_character_, which then yields NA inside the
+  # `set == "v1"` comparison below and errors with "missing value where
+  # TRUE/FALSE needed". Reject it here so bad input is reported consistently.
+  chk::chk_not_any_na(set)
   chk::chk_null_or(split, vld = chk::vld_character)
   chk::chk_string(summarize)
   chk::chk_flag(cas_lookup)
@@ -383,6 +406,15 @@ ssd_data_sets <- function(
     # inner tibbles already have Species, Conc, Chemical, Medium columns
     nms <- make.names(
       paste0("anztox_", dat$chemicalname_grouped, "_", dat$mediatype)
+    )
+    # Two CAS can share one chemicalname_grouped - e.g. Aroclor 1242 (53469219)
+    # and Aroclor 1254 (11097691) are both "Polychlorinated biphenyls" - which
+    # made one element unreachable, since `[[name]]` returns the first match.
+    # Disambiguate only the colliding names, using the CAS (the real identity),
+    # so every other element name stays stable for existing callers.
+    collides <- nms %in% nms[duplicated(nms)]
+    nms[collides] <- make.names(
+      paste0(nms[collides], "_", dat$casnumber_grouped[collides])
     )
     out <- dat$data
     names(out) <- nms

--- a/tests/testthat/test-get_ssddata.R
+++ b/tests/testthat/test-get_ssddata.R
@@ -151,3 +151,12 @@ test_that("envirotox_data_sets returns correct names", {
     )
   )
 })
+
+test_that("an unknown dataset name is an error", {
+  expect_error(
+    get_ssddata("no_such_dataset"),
+    "is not a dataset in ssddata"
+  )
+  # A near-miss typo is the case this guards: it previously returned NULL.
+  expect_error(get_ssddata("cmme_boron"), "is not a dataset in ssddata")
+})

--- a/tests/testthat/test-getdata.R
+++ b/tests/testthat/test-getdata.R
@@ -12,3 +12,7 @@ test_that("getdata loads ccme-data", {
     nrow = 28L
   ))
 })
+
+test_that("getdata errors rather than returning NULL for an unknown name", {
+  expect_error(suppressWarnings(ssddata:::getdata("no_such_dataset")))
+})

--- a/tests/testthat/test-ssd-data-sets.R
+++ b/tests/testthat/test-ssd-data-sets.R
@@ -237,3 +237,41 @@ test_that("mixing aggregated source with prefix in set errors informatively", {
     "Unknown `set` value"
   )
 })
+
+test_that("element names are unique for every set", {
+  for (s in c(
+    "v1",
+    "v2",
+    "anztox",
+    "wqbench",
+    "envirotox_acute",
+    "envirotox_chronic"
+  )) {
+    ds <- suppressMessages(ssd_data_sets(set = s))
+    expect_false(any(duplicated(names(ds))), info = s)
+  }
+})
+
+test_that("anztox names colliding on chemical x medium are split by CAS", {
+  ds <- suppressMessages(ssd_data_sets(set = "anztox"))
+  # Aroclor 1254 (11097691) and Aroclor 1242 (53469219) share the grouped
+  # chemical name "Polychlorinated biphenyls"; both must stay reachable.
+  pcb <- grep("^anztox_Polychlorinated", names(ds), value = TRUE)
+  expect_setequal(
+    pcb,
+    c(
+      "anztox_Polychlorinated.biphenyls_Freshwater_11097691",
+      "anztox_Polychlorinated.biphenyls_Freshwater_53469219"
+    )
+  )
+  expect_false(identical(ds[[pcb[1]]], ds[[pcb[2]]]))
+  # Non-colliding names keep their original chemical_medium form.
+  expect_true(any(names(ds) == "anztox_Zinc_Freshwater"))
+})
+
+test_that("set = NA errors informatively", {
+  expect_error(
+    ssd_data_sets(set = NA_character_),
+    "must not have any missing values"
+  )
+})


### PR DESCRIPTION
Closes #50, closes #54. Both live in `R/get_ssddata.R` and neither needs a data
rebuild, so they are handled together.

## #54 — argument handling

**Unknown `dataset_name` returned `NULL`.** `chk_string()` checked the type but
nothing checked that the name existed; `utils::data()` only warns on a miss, so
`get_ssddata("cmme_boron")` fell through to the "no grouping applied" branch and
returned `NULL` into the caller.

```r
get_ssddata("cmme_boron")
#> Error: `dataset_name` 'cmme_boron' is not a dataset in ssddata.
#>   See ssd_data_sets() for available datasets.
```

`getdata()` is guarded the same way, since it is used internally elsewhere.

**`set = NA` failed cryptically.** `chk_character()` admits `NA_character_`, which
then produced `NA` inside `set == "v1"`:

```r
ssd_data_sets(set = NA_character_)
#> Error: `set` must not have any missing values.     # was: missing value where TRUE/FALSE needed
```

`set = character(0)` still returns an empty list — unchanged, and still arguably
correct.

## #50 — anztox element names, option 2

Two CAS share the grouped name "Polychlorinated biphenyls" (Aroclor 1254,
`11097691`; Aroclor 1242, `53469219`), so `.split_aggregated()` emitted two
elements called `anztox_Polychlorinated.biphenyls_Freshwater` and `[[name]]`
could only ever reach the first.

Taking **option 2** from the issue — disambiguate only on collision:

```
anztox_Polychlorinated.biphenyls_Freshwater_11097691
anztox_Polychlorinated.biphenyls_Freshwater_53469219
```

All 172 other element names are untouched, so existing name-based selection keeps
working. Count stays at 174.

## Verified

- 174 anztox elements, **0 duplicated names**; the two PCB elements are distinct
- `get_ssddata("ccme_boron")` still returns 28 rows; `ssd_data_sets()` still
  returns 53 v2 sets
- Full suite passes, including four new blocks: uniqueness across all sets, the
  PCB CAS split, the `NA` set error, and the unknown-dataset errors

## Note

The issue also raised normalising anztox's `make.names()` style (`.` for spaces)
to the `_` used elsewhere. Left alone deliberately — that renames all 174
elements, which is the breaking change option 2 exists to avoid. Worth doing as
its own decision if you want it before CRAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)