### PR TITLE
Fix ssd_fits Units documentation and stale csiro Rd

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Bug fixes
 
+- Corrected the `ssd_fits` documentation, which described `Estimate`, `SE`,
+  `Lower` and `Upper` as being in ug/L and `Units` as always ug/L (GitHub #53).
+  Each fit is recorded on the scale of the dataset it was fitted to, so `Units`
+  is one of ug/L, mg/L or ng/L, and NA for the unitless `anon_*` datasets. The
+  11th column was also documented as `Source` when it is named `Reference`.
+
 - `ssd_data_sets(set = "anztox")` no longer returns two elements with the same
   name (GitHub #50). Two CAS can share one grouped chemical name — Aroclor 1254
   and Aroclor 1242 are both "Polychlorinated biphenyls" — which made one element

--- a/R/ssd-fits.R
+++ b/R/ssd-fits.R
@@ -25,14 +25,22 @@
 #'   \item{Version}{The version of the software (chr).}
 #'   \item{Distribution}{The name of the distribution (chr)}
 #'   \item{PC}{The percent of the community protected (int).}
-#'   \item{Estimate}{The estimated concentration, in ug/L (dbl).}
-#'   \item{SE}{The standard error of the estimated concentration, in ug/L (dbl).}
-#'   \item{Lower}{The lower 95% CI of the estimated concentration, in ug/L (dbl).}
-#'   \item{Upper}{The upper 95% CI of the estimated concentration, in ug/L (dbl).}
-#'   \item{Source}{The source of the fit (chr).}
+#'   \item{Estimate}{The estimated concentration, in the units given by Units
+#'     (dbl).}
+#'   \item{SE}{The standard error of the estimated concentration, in the units
+#'     given by Units (dbl).}
+#'   \item{Lower}{The lower 95% CI of the estimated concentration, in the units
+#'     given by Units (dbl).}
+#'   \item{Upper}{The upper 95% CI of the estimated concentration, in the units
+#'     given by Units (dbl).}
+#'   \item{Reference}{The source of the fit (chr).}
 #'   \item{Notes}{Additional information on the fitting process (chr).}
-#'   \item{Units}{The concentration units of Estimate, SE, Lower and Upper
-#'     (micrograms per Litre, ug/L) (chr).}
+#'   \item{Units}{The concentration units of Estimate, SE, Lower and Upper.
+#'     Each fit is recorded on the scale of the ssddata dataset it was fitted
+#'     to, so this is not uniform: one of "ug/L", "mg/L" or "ng/L" (for example
+#'     ccme_boron and ccme_chloride are mg/L, ccme_endosulfan is ng/L), and NA
+#'     for the anon_* datasets, whose concentrations are deliberately unitless
+#'     (chr).}
 #' }
 #'
 #' @examples

--- a/man/csiro_chlorine_marine.Rd
+++ b/man/csiro_chlorine_marine.Rd
@@ -6,7 +6,7 @@
 \title{Species Sensitivity Data for chlorine_marine}
 \format{
 An object of class \code{tbl_df} (inherits from \code{tbl},
-\code{data.frame}) with 30 rows and 3 columns.
+\code{data.frame}) with 30 rows and 9 columns.
 }
 \description{
 Species Sensitivity Data provided by the Commonwealth Scientific and
@@ -21,7 +21,13 @@ The columns are as follows:
 
 \describe{
 \item{Conc}{The chemical concentration in micrograms per Litre (dbl).}
+\item{Duration}{Test duration (chr).}
 \item{Group}{Taxonomic grouping information (chr).}
+\item{Life_stage}{Life stage of the test organism (chr).}
+\item{Notes}{Other notes (chr).}
+\item{Species}{The species names name (chr).}
+\item{Test_endpoint}{Endpoint statistic, EC10, NEC etc (chr).}
+\item{Toxicity_measure}{Type of toxicity measure used (chr).}
 \item{Units}{The concentration units of Conc (micrograms per Litre, ug/L) (chr).}
 
 Where toxicity measure is not a chronic NEC, EC10 or NOEC value,

--- a/man/ssd_fits.Rd
+++ b/man/ssd_fits.Rd
@@ -14,14 +14,22 @@ A tibble with 13 columns.
 \item{Version}{The version of the software (chr).}
 \item{Distribution}{The name of the distribution (chr)}
 \item{PC}{The percent of the community protected (int).}
-\item{Estimate}{The estimated concentration, in ug/L (dbl).}
-\item{SE}{The standard error of the estimated concentration, in ug/L (dbl).}
-\item{Lower}{The lower 95\% CI of the estimated concentration, in ug/L (dbl).}
-\item{Upper}{The upper 95\% CI of the estimated concentration, in ug/L (dbl).}
-\item{Source}{The source of the fit (chr).}
+\item{Estimate}{The estimated concentration, in the units given by Units
+(dbl).}
+\item{SE}{The standard error of the estimated concentration, in the units
+given by Units (dbl).}
+\item{Lower}{The lower 95\% CI of the estimated concentration, in the units
+given by Units (dbl).}
+\item{Upper}{The upper 95\% CI of the estimated concentration, in the units
+given by Units (dbl).}
+\item{Reference}{The source of the fit (chr).}
 \item{Notes}{Additional information on the fitting process (chr).}
-\item{Units}{The concentration units of Estimate, SE, Lower and Upper
-(micrograms per Litre, ug/L) (chr).}
+\item{Units}{The concentration units of Estimate, SE, Lower and Upper.
+Each fit is recorded on the scale of the ssddata dataset it was fitted
+to, so this is not uniform: one of "ug/L", "mg/L" or "ng/L" (for example
+ccme_boron and ccme_chloride are mg/L, ccme_endosulfan is ng/L), and NA
+for the anon_* datasets, whose concentrations are deliberately unitless
+(chr).}
 }
 }
 \usage{


### PR DESCRIPTION
Addresses **item 1 of #53**. Documentation only — no behaviour or data changes.

Items 2 and 3 of that issue concern `allchronic_data`, which does not exist on
`dev`, so they stay with `create_alldata`.

## The drift

The `@format` block described four columns as "in ug/L" and `Units` as always
ug/L. The values are correct; the documentation was not. Current build:

```
 mg/L  ng/L  ug/L  <NA>
   21    10   288    58
```

Each fit is recorded on the scale of the dataset it was fitted to — `ccme_boron`
and `ccme_chloride` in mg/L, `ccme_endosulfan` in ng/L — and `NA` for the 58
`anon_*` rows, whose concentrations are deliberately unitless. This is exactly
the assumption that caused #47, so it is worth stating precisely.

## Two extras found while in the file

- **`Source` is really `Reference`.** The 11th column has been documented under
  the wrong name. Fixed here; not previously reported.
- **`man/csiro_chlorine_marine.Rd` was stale.** #57 updated the roxygen source
  when the dataset went from 3 to 9 columns but never regenerated the `.Rd`, so
  the shipped help page still claimed 3 columns. My oversight in that PR;
  regenerated here.

## Note on DESCRIPTION

`devtools::document()` also wanted to replace `RoxygenNote: 7.3.3` with
`Config/roxygen2/version: 8.0.0`, reflecting my locally installed roxygen2. That
would bump the project's declared version as a side effect of a doc fix, so it
has been reverted. The regenerated `.Rd` diffs are pure content, with no
formatting artefacts from the newer roxygen.

Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)