### PR TITLE
Record roxygen2 8.0.0 in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,4 +49,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
roxygen2 8.0.0 replaces `RoxygenNote` with `Config/roxygen2/version`, so every
`devtools::document()` run was reintroducing this one-line change as incidental
churn in unrelated PRs (I reverted it out of #59 for exactly that reason).
Recording it deliberately stops it recurring.

```diff
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0
```

**No `.Rd` files change.** Running `document()` under 8.0.0 against current `dev`
regenerates all existing documentation byte-identically — `DESCRIPTION` is the
only modified file. So this carries no documentation or pkgdown risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)