### PR TITLE
Add package-wide data sweeps to the test suite

### DIFF
--- a/tests/testthat/helper-datasets.R
+++ b/tests/testthat/helper-datasets.R
@@ -1,0 +1,40 @@
+# Shared helpers for the package-wide data sweeps. testthat sources
+# helper-*.R before any test file, so these are available everywhere.
+
+# Cache for the sweeps below. The package-wide tests load every shipped data
+# object several times over; loading is deterministic, so caching keeps the
+# suite fast without weakening any assertion.
+.cache <- new.env(parent = emptyenv())
+
+# Load a package data object by name without attaching it to the global
+# environment (the same trick ssd_data_sets() uses internally).
+pkg_data <- function(name) {
+  if (!exists(name, envir = .cache, inherits = FALSE)) {
+    e <- new.env()
+    utils::data(list = name, package = "ssddata", envir = e)
+    assign(name, e[[name]], envir = .cache)
+  }
+  get(name, envir = .cache, inherits = FALSE)
+}
+
+# Names of every data object shipped by the package.
+shipped_items <- function() {
+  sort(utils::data(package = "ssddata")$results[, "Item"])
+}
+
+# Shipped items that are data frames. Excludes envirotox_data, which is a
+# named list of three tibbles rather than a tibble itself.
+shipped_data_frames <- function() {
+  items <- shipped_items()
+  items[vapply(items, function(x) is.data.frame(pkg_data(x)), logical(1))]
+}
+
+# The five source families that ship both per-chemical objects and an
+# aggregate `{prefix}_data` object.
+source_families <- c("aims", "anzg", "ccme", "csiro", "anon")
+
+# Per-chemical objects for a family (i.e. the aggregate excluded).
+family_components <- function(prefix) {
+  items <- shipped_items()
+  setdiff(grep(paste0("^", prefix, "_"), items, value = TRUE), paste0(prefix, "_data"))
+}

--- a/tests/testthat/test-data-aggregates.R
+++ b/tests/testthat/test-data-aggregates.R
@@ -1,0 +1,101 @@
+# The five source families each ship per-chemical objects plus an aggregate
+# `{prefix}_data` object. Nothing previously guarded that the two stay in
+# step, so a per-chemical dataset could be rebuilt (or added, as the ANZG set
+# regularly is) while its aggregate went stale. These tests assert the
+# aggregate is exactly the union of its components.
+
+test_that("each source family ships an aggregate plus at least one component", {
+  items <- shipped_items()
+  for (p in source_families) {
+    expect_true(paste0(p, "_data") %in% items, label = paste0(p, "_data exists"))
+    expect_gt(length(family_components(p)), 0L)
+  }
+})
+
+test_that("aggregate row count equals the sum of its component datasets", {
+  for (p in source_families) {
+    comps <- family_components(p)
+    n_comp <- sum(vapply(comps, function(x) nrow(pkg_data(x)), integer(1)))
+    expect_identical(
+      nrow(pkg_data(paste0(p, "_data"))),
+      n_comp,
+      label = paste0(p, "_data rows vs sum of components")
+    )
+  }
+})
+
+test_that("every component Conc value is present in its aggregate", {
+  # Row counts alone would not catch a component being rebuilt with different
+  # values, so match on the concentrations themselves. Rounded to guard
+  # against build-time floating-point drift.
+  for (p in source_families) {
+    agg <- round(pkg_data(paste0(p, "_data"))$Conc, 10)
+    for (cc in family_components(p)) {
+      comp <- round(pkg_data(cc)$Conc, 10)
+      expect_true(
+        all(comp %in% agg),
+        label = paste("all", cc, "Conc values present in", paste0(p, "_data"))
+      )
+    }
+  }
+})
+
+test_that("every component species is present in its aggregate", {
+  for (p in setdiff(source_families, "anon")) {
+    agg <- pkg_data(paste0(p, "_data"))$Species
+    for (cc in family_components(p)) {
+      expect_true(
+        all(pkg_data(cc)$Species %in% agg),
+        label = paste("all", cc, "species present in", paste0(p, "_data"))
+      )
+    }
+  }
+})
+
+test_that("aggregates carry a Chemical column that components identify by name", {
+  # Component objects are named {prefix}_{chemical}_{medium} and drop the
+  # Chemical column; the aggregate re-adds it. Every aggregate Chemical value
+  # must therefore be traceable to at least one component name.
+  for (p in setdiff(source_families, "anon")) {
+    agg <- pkg_data(paste0(p, "_data"))
+    expect_true("Chemical" %in% names(agg), label = paste0(p, "_data has Chemical"))
+    comps <- family_components(p)
+    for (chem in unique(agg$Chemical)) {
+      # Case-insensitive: ccme uses "Boron" where the object is ccme_boron,
+      # and anzg_chromium_III_fresh keeps the roman numeral capitalised.
+      token <- tolower(gsub("[^A-Za-z0-9]+", "_", chem))
+      expect_true(
+        any(grepl(token, tolower(comps), fixed = TRUE)),
+        label = paste0("chemical '", chem, "' in ", p, "_data has a component dataset")
+      )
+    }
+  }
+})
+
+test_that("anzg_data preserves the three hardness freshwater variants", {
+  # Collapsing these to plain "freshwater" would silently merge three
+  # separate ANZG guideline datasets (CLAUDE.md section 7: never collapse).
+  anzg <- pkg_data("anzg_data")
+  nitrate <- anzg[anzg$Chemical == "nitrate", ]
+  expect_setequal(
+    unique(nitrate$Medium),
+    c("Soft freshwater", "Moderate freshwater", "Hard freshwater")
+  )
+  expect_identical(nrow(pkg_data("anzg_nitrate_soft_fresh")), 14L)
+  expect_identical(nrow(pkg_data("anzg_nitrate_moderate_fresh")), 11L)
+  expect_identical(nrow(pkg_data("anzg_nitrate_hard_fresh")), 12L)
+})
+
+test_that("component datasets omit the columns their name already encodes", {
+  # Per-chemical objects encode chemical (and medium, for aims/anzg/csiro) in
+  # the object name, so carrying the column too would be redundant and could
+  # drift out of step with the name.
+  for (p in c("aims", "anzg", "csiro")) {
+    for (cc in family_components(p)) {
+      expect_false(
+        "Chemical" %in% names(pkg_data(cc)),
+        label = paste(cc, "has no redundant Chemical column")
+      )
+    }
+  }
+})

--- a/tests/testthat/test-data-integrity.R
+++ b/tests/testthat/test-data-integrity.R
@@ -1,0 +1,97 @@
+# Package-wide sweeps over every shipped data object.
+#
+# The pre-existing tests spot-check three datasets (ccme_boron, ccme_data,
+# anzg_metolachlor_fresh). These tests instead assert the structural contract
+# that EVERY dataset must satisfy to be usable with ssdtools, so a new or
+# rebuilt dataset cannot ship with a broken Conc/Species/Units column
+# unnoticed. Failures name the offending dataset(s) rather than just the
+# expectation, so the sweep is diagnostic.
+
+# Collect the datasets failing a per-dataset predicate, for informative output.
+.offenders <- function(items, f) {
+  bad <- vapply(items, function(x) isTRUE(f(pkg_data(x))), logical(1))
+  items[bad]
+}
+
+test_that("every shipped data object is a tibble, except the envirotox_data list", {
+  items <- shipped_items()
+  for (it in setdiff(items, "envirotox_data")) {
+    expect_s3_class(pkg_data(it), "tbl_df")
+  }
+  expect_type(pkg_data("envirotox_data"), "list")
+  expect_false(is.data.frame(pkg_data("envirotox_data")))
+})
+
+test_that("no shipped data frame has empty, duplicated or non-syntactic column names", {
+  items <- shipped_data_frames()
+  bad <- .offenders(items, function(d) {
+    nms <- names(d)
+    anyDuplicated(nms) > 0 || any(is.na(nms)) || any(trimws(nms) == "")
+  })
+  expect_identical(bad, character(0), label = "datasets with bad column names")
+})
+
+test_that("no shipped data frame is empty", {
+  items <- shipped_data_frames()
+  bad <- .offenders(items, function(d) nrow(d) == 0L || ncol(d) == 0L)
+  expect_identical(bad, character(0), label = "empty datasets")
+})
+
+test_that("Conc is numeric, non-missing and finite wherever it is present", {
+  items <- shipped_data_frames()
+  items <- items[vapply(items, function(x) "Conc" %in% names(pkg_data(x)), logical(1))]
+  # Sanity: the sweep must actually be looking at something.
+  expect_gt(length(items), 50L)
+
+  not_numeric <- .offenders(items, function(d) !is.numeric(d$Conc))
+  expect_identical(not_numeric, character(0), label = "datasets with non-numeric Conc")
+
+  not_finite <- .offenders(items, function(d) any(is.na(d$Conc) | !is.finite(d$Conc)))
+  expect_identical(not_finite, character(0), label = "datasets with missing/infinite Conc")
+
+  # A zero maps to -Inf on the log scale an SSD is fitted on. wqbench_data
+  # carried 20 such rows from ECOTOX until they were dropped at build time
+  # (GitHub #49); this sweep covers every shipped dataset, not just that one.
+  nonpositive <- .offenders(items, function(d) any(d$Conc <= 0))
+  expect_identical(nonpositive, character(0), label = "datasets with non-positive Conc")
+})
+
+test_that("Species is character, non-missing and non-empty wherever it is present", {
+  items <- shipped_data_frames()
+  items <- items[vapply(items, function(x) "Species" %in% names(pkg_data(x)), logical(1))]
+  expect_gt(length(items), 50L)
+
+  bad <- .offenders(items, function(d) {
+    !is.character(d$Species) || any(is.na(d$Species)) || any(trimws(d$Species) == "")
+  })
+  expect_identical(bad, character(0), label = "datasets with missing/blank Species")
+})
+
+test_that("Units, where present, uses the ug/L | mg/L | ng/L vocabulary", {
+  # ssd_fits is excluded: its Units column describes the fitted estimates and
+  # is NA for the anon_* datasets, which ship no Units of their own. It is
+  # covered in test-ssd_fits.R.
+  items <- setdiff(shipped_data_frames(), "ssd_fits")
+  items <- items[vapply(items, function(x) "Units" %in% names(pkg_data(x)), logical(1))]
+  expect_gt(length(items), 40L)
+
+  bad <- .offenders(items, function(d) {
+    !is.character(d$Units) ||
+      any(is.na(d$Units)) ||
+      !all(d$Units %in% c("ug/L", "mg/L", "ng/L"))
+  })
+  expect_identical(bad, character(0), label = "datasets with an unexpected Units value")
+})
+
+test_that("Units is constant within each per-chemical dataset", {
+  # A per-chemical dataset mixing units would make Conc uninterpretable and is
+  # the exact failure mode behind issue #47. The `{prefix}_data` aggregates are
+  # exempt: ccme_data legitimately spans mg/L, ug/L and ng/L across chemicals.
+  items <- setdiff(shipped_data_frames(), "ssd_fits")
+  items <- items[!grepl("_data$", items)]
+  items <- items[vapply(items, function(x) "Units" %in% names(pkg_data(x)), logical(1))]
+
+  bad <- .offenders(items, function(d) length(unique(d$Units)) != 1L)
+  expect_identical(bad, character(0), label = "per-chemical datasets with mixed Units")
+})
+

--- a/tests/testthat/test-get_ssddata-args.R
+++ b/tests/testthat/test-get_ssddata-args.R
@@ -1,0 +1,99 @@
+# Argument validation and edge-case behaviour for get_ssddata(). The existing
+# test-get_ssddata.R covers the happy paths (grouping, filtering, messages);
+# these cover what happens when arguments are wrong or unusual, including two
+# branches of the function that had no coverage at all: the explicit
+# `filter_val = NA` handling and the non-default `conc` / `use_gmmean`
+# arguments.
+
+test_that("get_ssddata validates its arguments", {
+  expect_error(get_ssddata(1), "`dataset_name` must be a string")
+  expect_error(get_ssddata(c("ccme_boron", "ccme_silver")), "`dataset_name` must be a string")
+  expect_error(get_ssddata(NA_character_), "`dataset_name` must be a string")
+  expect_error(get_ssddata("ccme_boron", use_gmmean = "yes"), "`use_gmmean` must be a flag")
+  expect_error(get_ssddata("ccme_boron", use_gmmean = NA), "`use_gmmean` must be a flag")
+  expect_error(get_ssddata("ccme_boron", conc = 1), "`conc` must be a string")
+  expect_error(get_ssddata("ccme_boron", filter_val = 1), "`filter_val` must be")
+})
+
+test_that("filter_val = NA is treated as no filter", {
+  # The function explicitly converts a missing filter_val to NULL up front so
+  # callers can pass through an absent filter from a lookup table.
+  unfiltered <- suppressMessages(get_ssddata("ccme_boron"))
+  na_filter <- suppressMessages(get_ssddata("ccme_boron", filter_val = NA))
+  expect_identical(na_filter, unfiltered)
+  expect_identical(nrow(na_filter), 28L)
+})
+
+test_that("use_gmmean = FALSE returns the raw data even when duplicates exist", {
+  raw <- suppressMessages(get_ssddata("aims_aluminium_marine", use_gmmean = FALSE))
+  grouped <- suppressMessages(get_ssddata("aims_aluminium_marine", use_gmmean = TRUE))
+  expect_identical(nrow(raw), 20L)
+  expect_identical(nrow(grouped), 17L)
+  expect_identical(raw, pkg_data("aims_aluminium_marine"))
+  expect_message(
+    get_ssddata("aims_aluminium_marine", use_gmmean = FALSE),
+    "No grouping has been applied"
+  )
+})
+
+test_that("the geometric mean is applied to the column named by `conc`", {
+  grouped <- suppressMessages(get_ssddata("aims_aluminium_marine"))
+  raw <- pkg_data("aims_aluminium_marine")
+  expect_identical(names(grouped), c("Species", "Conc"))
+
+  # Spot-check one geomeaned species against gm_mean() of its raw values.
+  dups <- names(which(table(raw$Species) > 1L))
+  expect_gt(length(dups), 0L)
+  spp <- dups[1]
+  expect_equal(
+    grouped$Conc[grouped$Species == spp],
+    gm_mean(raw$Conc[raw$Species == spp])
+  )
+  # Species with a single record pass through unchanged.
+  singles <- setdiff(raw$Species, dups)
+  expect_equal(
+    grouped$Conc[match(singles, grouped$Species)],
+    raw$Conc[match(singles, raw$Species)]
+  )
+})
+
+test_that("spp_vec uses every grouping column present in the data", {
+  # anzg_data carries both Species and Genus and has duplicate pairs, so both
+  # default spp_vec columns are used: the message names both and the key
+  # column is the two pasted together.
+  expect_message(
+    get_ssddata("anzg_data"),
+    "grouped by Species, Genus"
+  )
+  grouped <- suppressMessages(get_ssddata("anzg_data"))
+  expect_identical(names(grouped), c("Species_Genus", "Conc"))
+  expect_true(all(grepl("_", grouped$Species_Genus)))
+
+  # Per-chemical anzg datasets have no duplicate Species/Genus pairs, so they
+  # short-circuit to the raw data instead.
+  expect_message(
+    get_ssddata("anzg_copper_marine"),
+    "No grouping has been applied"
+  )
+})
+
+test_that("an unrecognised spp_vec falls back to the raw data", {
+  expect_message(
+    out <- get_ssddata("ccme_boron", spp_vec = "NotAColumn"),
+    "No grouping has been applied"
+  )
+  expect_identical(out, pkg_data("ccme_boron"))
+})
+
+test_that("filtering to a single Domain level narrows the data", {
+  temperate <- suppressMessages(
+    get_ssddata("aims_aluminium_marine", spp_vec = NA, filter_val = "Domain_Temperate")
+  )
+  expect_true(all(temperate$Domain == "Temperate"))
+  expect_lt(nrow(temperate), nrow(pkg_data("aims_aluminium_marine")))
+})
+
+test_that("getdata retrieves any shipped dataset by name", {
+  expect_identical(ssddata:::getdata("anzg_boron_fresh"), pkg_data("anzg_boron_fresh"))
+  expect_identical(ssddata:::getdata("wqbench_data"), pkg_data("wqbench_data"))
+})

--- a/tests/testthat/test-ssd_fits.R
+++ b/tests/testthat/test-ssd_fits.R
@@ -1,0 +1,85 @@
+# ssd_fits is the package's reference table of gazetted / previously published
+# SSD fits. It had no schema test: test-units-consistency.R used it only as an
+# oracle for the raw data. These tests cover the table in its own right, and
+# in particular replace the heuristic HC-below-max unit check with a direct
+# one - the Units column of a fit must equal the Units of the dataset it was
+# fitted to. That is the exact invariant issue #47 violated.
+
+test_that("ssd_fits has the documented shape", {
+  expect_s3_class(ssd_fits, "tbl_df")
+  expect_identical(ncol(ssd_fits), 13L)
+  expect_identical(
+    names(ssd_fits),
+    c(
+      "Dataset", "Filter", "Software", "Version", "Distribution", "PC",
+      "Estimate", "SE", "Lower", "Upper", "Reference", "Notes", "Units"
+    )
+  )
+  expect_identical(nrow(ssd_fits), 377L)
+})
+
+test_that("every ssd_fits Dataset is a data object shipped by the package", {
+  # A fit referring to a renamed or removed dataset is unusable, and the
+  # dataset naming roadmap (CLAUDE.md section 8) will rename objects.
+  expect_true(all(unique(ssd_fits$Dataset) %in% shipped_items()))
+  expect_true(is.character(ssd_fits$Dataset))
+  expect_false(any(is.na(ssd_fits$Dataset)))
+})
+
+test_that("PC and Software use their expected vocabularies", {
+  expect_setequal(unique(ssd_fits$PC), c(80, 90, 95, 99))
+  expect_setequal(
+    unique(ssd_fits$Software),
+    c("Burrlioz", "ssdtools", "shinyssdtools")
+  )
+  # Distribution is recorded for every fit bar the twelve Burrlioz v2.0
+  # csiro_nickel_fresh rows, whose source did not report which distribution
+  # Burrlioz selected.
+  na_dist <- ssd_fits[is.na(ssd_fits$Distribution), ]
+  expect_identical(nrow(na_dist), 12L)
+  expect_setequal(unique(na_dist$Dataset), "csiro_nickel_fresh")
+})
+
+test_that("Estimate is non-negative and confidence bounds bracket it", {
+  expect_true(all(ssd_fits$Estimate >= 0, na.rm = TRUE))
+  ci <- ssd_fits[!is.na(ssd_fits$Lower) & !is.na(ssd_fits$Upper) & !is.na(ssd_fits$Estimate), ]
+  expect_gt(nrow(ci), 0L)
+  expect_true(all(ci$Lower <= ci$Estimate))
+  expect_true(all(ci$Estimate <= ci$Upper))
+  expect_true(all(ssd_fits$SE >= 0, na.rm = TRUE))
+})
+
+test_that("ssd_fits Units matches the Units of the dataset that was fitted", {
+  # Direct guard for the issue #47 class of bug: an estimate left on a
+  # different scale from the raw data (ANZG boron/nitrate in mg/L, dioxins in
+  # ng/L). Unlike the HC-below-max heuristic this catches a mismatch even when
+  # the wrong-scale value still happens to fall below the data maximum.
+  mismatched <- character(0)
+  for (id in unique(ssd_fits$Dataset)) {
+    d <- pkg_data(id)
+    fit_units <- unique(ssd_fits$Units[ssd_fits$Dataset == id])
+    data_units <- if ("Units" %in% names(d)) unique(d$Units) else NA_character_
+    if (!identical(sort(fit_units), sort(data_units))) {
+      mismatched <- c(mismatched, id)
+    }
+  }
+  expect_identical(
+    mismatched,
+    character(0),
+    label = "datasets whose ssd_fits Units differ from the dataset's own Units"
+  )
+})
+
+test_that("ssd_fits Units is NA only for the anon_* datasets", {
+  # The anon_* datasets ship no Units column - their concentrations are
+  # deliberately unitless - so their fits carry NA Units. Any other NA means a
+  # fit was added without recording its scale.
+  na_units <- unique(ssd_fits$Dataset[is.na(ssd_fits$Units)])
+  expect_setequal(na_units, c("anon_a", "anon_b", "anon_c", "anon_d", "anon_e"))
+  expect_true(all(ssd_fits$Units[!is.na(ssd_fits$Units)] %in% c("ug/L", "mg/L", "ng/L")))
+})
+
+test_that("Units is constant within a dataset's fits", {
+  n_units <- tapply(ssd_fits$Units, ssd_fits$Dataset, function(x) length(unique(x)))
+  expect_true(all(n_units == 1L))
+})


### PR DESCRIPTION
The last pre-CRAN item. Five test files sweeping every shipped dataset rather
than checking them one at a time. **468 tests pass**, up from 318 on `dev`.

| file | covers |
|---|---|
| `helper-datasets.R` | cached loaders + shipped-item accessors |
| `test-data-integrity.R` | types, column names, `Conc`, `Species`, `Units` vocabulary |
| `test-data-aggregates.R` | each `{prefix}_data` against its component datasets |
| `test-ssd_fits.R` | shape, `PC`/`Software` vocabularies, per-dataset `Units` |
| `test-get_ssddata-args.R` | argument handling, geomean grouping, `spp_vec` |

## What was left behind

These were written against `create_alldata`, so the port drops everything that
has no meaning on `dev`:

- `test-allchronic-data.R` in full, and the `all_chronic_sets()` helper — no
  such object here;
- the two curated `Timeframe` blocks — that column is part of the alldata work;
- `test-ssd-data-sets.R` was **not** ported. Its `dev` counterpart has moved
  well past the version it was written against (131 insertions / 109 deletions),
  and the non-allchronic coverage it added is already on `dev` from #58, #60 and
  #61.

## Defect pins reconciled

The suite deliberately pinned then-current defects. Four are now fixed, so the
pins are gone:

| pin | issue | resolution |
|---|---|---|
| `"...except the known wqbench_data zeros"` | #49 | rewritten as a non-positive `Conc` sweep over **all** shipped datasets — broader than the pin it replaces |
| `"Medium vocabulary is pinned per source family"` | #52 | dropped; `dev` already asserts one harmonised vocabulary (added in #61) |
| `"an unknown dataset name warns and returns NULL"` | #54 | dropped; `dev` already asserts it errors (added in #58) |
| `"element names are unique, bar the known anztox PCB collision"` | #50 | in the unported file; `dev` already asserts uniqueness for every set (#58) |

Pins for defects that are **not** fixed — the imidacloprid overlap (#51) and the
`allchronic_data` `CAS`/`NRecords` items of #53 — stay with `create_alldata`,
since they concern an object that does not exist here.

Two other adjustments: the ANZG hardness variants are asserted capitalised
(#52), and a `getdata()` assertion that used `allchronic_data` now uses
`wqbench_data`.

## Note

`test-ccme-boron.R` and `test-ccme-data.R` both label a block `"ccme_data"`.
Pre-existing on `dev` and harmless — flagging only so it is not mistaken for
something this PR introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)