### PR TITLE
Fall back to CAS for anztox elements with no chemical name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Bug fixes
 
+- `ssd_data_sets()` no longer emits elements named `anztox_NA_Freshwater` and
+  `anztox_NA_Marine` (GitHub #62). Two `anztox_data` rows have a missing
+  `chemicalname_grouped` (CAS 7782492, selenium), so the element name now falls
+  back to the CAS and the 18 records stay identifiable. This is a naming guard
+  only — the missing name in `anztox_data` itself requires the anztox source to
+  be rebuilt against the master CAS lookup, which #62 tracks.
+
 - Harmonised the `Medium` vocabulary across sources (GitHub #52). `aims_data`,
   `csiro_data` and `anzg_data` used lower-case tokens, with csiro using `fresh`
   where others used a form of `freshwater`, so `subset(x, Medium ==

--- a/R/get_ssddata.R
+++ b/R/get_ssddata.R
@@ -390,6 +390,18 @@ ssd_data_sets <- function(
   })
 }
 
+# The chemical token used in anztox element names. `chemicalname_grouped` is
+# NA where the CAS parent lookup used by the anztox build has no entry and the
+# database supplies no common name - currently CAS 7782492 (selenium), which
+# produced two elements literally named `anztox_NA_*`. Falling back to the CAS
+# keeps them identifiable and matches the collision handling below, which also
+# treats the CAS as the real identity. This is a naming guard only: the
+# underlying NA in `anztox_data$chemicalname_grouped` needs the source rebuilt
+# against the master lookup. See GitHub #62.
+.anztox_chem_token <- function(chemical, cas) {
+  ifelse(is.na(chemical), as.character(cas), as.character(chemical))
+}
+
 # Split an aggregated dataset into a named list of per-chemical tibbles.
 # All column names are now standardised (Species, Conc, Chemical, Medium)
 # in the data-raw/ build scripts.
@@ -405,7 +417,12 @@ ssd_data_sets <- function(
     # anztox_data is a nested tibble: chemicalname_grouped x mediatype x data
     # inner tibbles already have Species, Conc, Chemical, Medium columns
     nms <- make.names(
-      paste0("anztox_", dat$chemicalname_grouped, "_", dat$mediatype)
+      paste0(
+        "anztox_",
+        .anztox_chem_token(dat$chemicalname_grouped, dat$casnumber_grouped),
+        "_",
+        dat$mediatype
+      )
     )
     # Two CAS can share one chemicalname_grouped - e.g. Aroclor 1242 (53469219)
     # and Aroclor 1254 (11097691) are both "Polychlorinated biphenyls" - which
@@ -496,7 +513,10 @@ ssd_data_sets <- function(
     anztox_raw <- .pkgdata("anztox_data")
     for (i in seq_len(nrow(anztox_raw))) {
       d <- anztox_raw$data[[i]]
-      chem <- anztox_raw$chemicalname_grouped[i]
+      chem <- .anztox_chem_token(
+        anztox_raw$chemicalname_grouped[i],
+        anztox_raw$casnumber_grouped[i]
+      )
       med <- anztox_raw$mediatype[i]
       nm <- make.names(paste0("anztox_", chem, "_", med))
       all_out[[nm]] <- d

--- a/tests/testthat/test-ssd-data-sets.R
+++ b/tests/testthat/test-ssd-data-sets.R
@@ -341,3 +341,22 @@ test_that("Medium uses one harmonised vocabulary across all sources", {
     )
   )
 })
+
+test_that("no element name contains NA where a chemical name is missing", {
+  # anztox_data has two rows with a NA chemicalname_grouped (CAS 7782492,
+  # selenium), which produced elements literally named anztox_NA_*. The name
+  # falls back to the CAS so they stay identifiable; the underlying NA is
+  # GitHub #62 and needs the anztox source rebuilt.
+  for (s in c("anztox", "alldata")) {
+    ds <- suppressMessages(ssd_data_sets(set = s))
+    expect_identical(grep("_NA_", names(ds), value = TRUE), character(0), info = s)
+    expect_true(all(c(
+      "anztox_7782492_Freshwater",
+      "anztox_7782492_Marine"
+    ) %in% names(ds)), info = s)
+  }
+
+  ds <- suppressMessages(ssd_data_sets(set = "anztox"))
+  expect_identical(nrow(ds[["anztox_7782492_Freshwater"]]), 5L)
+  expect_identical(nrow(ds[["anztox_7782492_Marine"]]), 13L)
+})


### PR DESCRIPTION
Pre-CRAN mitigation for #62, which stays open for the data fix.

## Why this is pre-CRAN

I originally opened #62 as a follow-up rather than triaging it into the
pre-CRAN queue — an oversight. It ships on `dev` and is user-facing in three
places:

```
set = "anztox"    →  anztox_NA_Freshwater, anztox_NA_Marine
set = "alldata"   →  anztox_NA_Freshwater, anztox_NA_Marine
anztox_data       →  2 rows with NA chemicalname_grouped
```

It is the same class of defect as #50, which was treated as pre-CRAN — the same
dataset, and names derived from a chemical name where the CAS is the real
identity. Arguably worse: #50 left one element unreachable but identifiable,
whereas here 18 selenium records sit under a set called `NA`.

## What this changes

Both call sites now share `.anztox_chem_token()`, which falls back to the CAS
when `chemicalname_grouped` is `NA`:

```
anztox_NA_Freshwater  →  anztox_7782492_Freshwater
anztox_NA_Marine      →  anztox_7782492_Marine
```

That matches the collision handling added in #58, which already treats the CAS
as the real identity.

## What this does NOT change

`anztox_data$chemicalname_grouped` is still `NA` for those two rows. Anyone
inspecting the object directly still sees the hole, and the substance is
identified by CAS rather than as "Selenium". **This is a naming guard, not a
fix.**

The real fix needs `data-raw/anztox/DATASET.R` pointed at the master lookup —
which already maps `7782492 → Selenium` — plus a build-time guard against any
`NA` name, and a rebuild against the `infogathering` PostgreSQL DB (Windows
only). #62 remains open and now records both parts.

## Verified

- `set = "anztox"`: 174 elements, 0 `_NA_` names, 0 duplicates
- `set = "alldata"`: 2,369 elements, 0 `_NA_` names
- The #58 PCB disambiguation is intact
  (`anztox_Polychlorinated.biphenyls_Freshwater_11097691` / `...53469219`)
- The 18 selenium records are reachable: 5 freshwater, 13 marine
- Full suite passes, with a new regression block covering both set types

🤖 Generated with [Claude Code](https://claude.com/claude-code)