### PR TITLE
Add selenium to the anztox CAS lookup and read the tracked copy

### DIFF
--- a/data-raw/anztox/DATASET.R
+++ b/data-raw/anztox/DATASET.R
@@ -94,7 +94,7 @@ build_reference_bib <- function(
 # INPUTS
 # =============================================================================
 cas_parent_lookup <- read_csv(
-  "data-raw/anztox/raw/cas_parent_lookup.csv",
+  "data-raw/anztox/cas_parent_lookup.csv",
   col_types = cols(
     chemicalname = col_character(),
     casnumber = col_character(),

--- a/data-raw/anztox/cas_parent_lookup.csv
+++ b/data-raw/anztox/cas_parent_lookup.csv
@@ -39,3 +39,4 @@ casnumber,chemicalname,parent_cas_dashed,parent_casnumber,parent_name,match_rati
 7783064,Hydrogen sulfide,"	7783-06-4",7783064,Hydrogen sulfide,CAS formatting: 7783064 == 7783-06-4,n
 56359,Tributyltin,56-35-9,56360,Tributyltin,regulatory_representative,n
 1461229,Tributyltin,56-35-9,56360,Tributyltin,regulatory_representative,n
+7782492,Selenium,7782-49-2,7782492,Selenium,direct - no simpler parent,n


### PR DESCRIPTION
Fixes the root cause of #62 in the lookup, rather than working around it in the
naming layer. Supersedes #65, which is closed unmerged.

## The lookup row

CAS 7782492 had no entry in the anztox seed lookup, and the database supplies no
common name, so `coalesce(parent_name, commonname)` left `chemicalname_grouped`
`NA` for two `anztox_data` rows. The master lookup already had the mapping, so
the fix is one row:

```
7782492,Selenium,7782-49-2,7782492,Selenium,direct - no simpler parent,n
```

The join is on `casnumber`, and this is a self-parent row, so it affects that CAS
and nothing else. (The master writes the rationale with an em-dash; ASCII is used
here to keep the seed file free of non-ASCII bytes, as it is today.)

## The path

The build read `data-raw/anztox/raw/cas_parent_lookup.csv`, which `.gitignore`
excludes via `data-raw/**/raw/`. So the file actually driving the build was not
in version control, and editing the tracked copy at
`data-raw/anztox/cas_parent_lookup.csv` would have looked right in review while
changing nothing at build time.

It now reads the tracked copy. I checked the two before switching: `diff`
reported every line as changed, but that is **line endings only** — the `raw/`
copy is CRLF, the tracked copy LF. Content was identical, 40 rows each, so
repointing loses nothing. The untracked copy has been moved to `superceded/`.

## Scope

Deliberately narrow. #62 also floats repointing the build at the full 6,378-row
master lookup, which would change grouped names for any anztox CAS currently
falling through to `commonname`. That is a much larger change needing a diff of
what else it moves, and is left for the #62 follow-up.

## This does not change the shipped package yet

`data-raw/` is `.Rbuildignore`d, and `anztox_data.rda` is unchanged. The fix
takes effect on the next `anztox_data` rebuild, which needs the `infogathering`
PostgreSQL DB (Windows only). No NEWS entry for that reason — nothing
user-visible has changed.

**Until that rebuild, `ssd_data_sets()` still emits `anztox_NA_Freshwater` and
`anztox_NA_Marine`.** With #65 closed there is no interim guard, which is the
deliberate trade for keeping this clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)